### PR TITLE
feat: set API URL for production mode

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -6,12 +6,11 @@ import { Status } from "./models/Status";
 import { TradehistoryResponse } from "./models/TradehistoryResponse";
 import { TradinglimitsResponse } from "./models/TradinglimitsResponse";
 import { isElectron } from "./common/appUtil";
-import { XUD_DOCKER_LOCAL_MAINNET_URL } from "./constants";
 
 const url =
   process.env.NODE_ENV === "development"
     ? process.env.REACT_APP_API_URL
-    : XUD_DOCKER_LOCAL_MAINNET_URL;
+    : window.location.origin;
 const path = `${url}/api/v1`;
 const xudPath = `${path}/xud`;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,8 +3,6 @@ export const XUD_DISCORD_URL = "https://discord.com/invite/YgDhMSn";
 export const XUD_DOCKER_DOCS_URL =
   "https://docs.exchangeunion.com/start-earning/market-maker-guide";
 
-export const XUD_DOCKER_LOCAL_MAINNET_URL = "http://localhost:8889";
-
 export const XUD_NOT_READY = [
   "Error",
   "Container disabled",


### PR DESCRIPTION
This PR implements setting the API URL in production to `window.location.origin` as the API always runs on the same address where the dashboard is served from.