### PR TITLE
chore: rename 'XUD Explorer' to 'XUD UI'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# XUD EXPLORER DASHBOARD
+# XUD UI DASHBOARD
 
 A graphical user interface for interacting with a [xud-docker](https://github.com/ExchangeUnion/xud-docker) environment.
 

--- a/public/index.html
+++ b/public/index.html
@@ -23,7 +23,7 @@
       content="UI for market makers who want to have a visual way to control their xud environment"
     />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>XUD Explorer</title>
+    <title>XUD UI</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "XUD Explorer",
-  "name": "XUD Explorer",
+  "short_name": "XUD UI",
+  "name": "XUD UI",
   "icons": [
     {
       "src": "assets/favicon.ico",

--- a/src/dashboard/Dashboard.tsx
+++ b/src/dashboard/Dashboard.tsx
@@ -143,7 +143,7 @@ const Dashboard = (): ReactElement => {
             component="p"
             color="textSecondary"
           >
-            XUD Explorer
+            XUD UI
           </Typography>
           <List className={classes.menuContainer}>
             {menuItems.map((item) => (


### PR DESCRIPTION
This PR renames the app back to` XUD UI (Dashboard)` until it has a proper name.