### PR TITLE
chore: trigger ci builds on both pushes and pull requests to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
Enables to trigger the ci builds (lint, test) also when the pull request is made from a forked repository.